### PR TITLE
Added iodine server + minor updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', '2.0.0.beta2'
+gem 'sinatra'
 gem 'json'
 gem 'oauth'
 
@@ -22,7 +22,13 @@ group :app_servers do
   gem 'passenger'
   gem 'passenger-rails'
   gem 'rhebok'
-  platforms :ruby, :rbx do
+  platforms :rbx do
+    gem 'unicorn'
+    gem 'unicorn-rails'
+    gem 'thin'
+  end
+  platforms :ruby do
+    gem 'iodine'
     gem 'unicorn'
     gem 'unicorn-rails'
     gem 'thin'

--- a/config/ey.yml
+++ b/config/ey.yml
@@ -30,5 +30,6 @@ environments:
   asa_unicorn: {}
   asa_passenger: {}
   asa_puma: {}
+  asa_iodine: {}
 defaults:
   migrate: false

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SERVERS=(passenger puma Rhebok thin unicorn)
+SERVERS=(iodine passenger puma Rhebok thin unicorn)
 
 # stop servers
 pkill -f ruby &> /dev/null
@@ -8,9 +8,13 @@ pkill -f ruby &> /dev/null
 # seeds
 ruby ./setup.rb &> /dev/null
 
+# clear old performance data
+rm -R performance
+
 # run servers
 for i in "${!SERVERS[@]}"; do
-  rackup -s ${SERVERS[$i]} --port "300$i" -E production config.ru &> /dev/null &
+  mkdir -p "performance/${SERVERS[$i]}"
+  bundler exec rackup -s ${SERVERS[$i]} --port "300$i" -E production config.ru &> /dev/null &
 done
 sleep 10
 

--- a/setup.rb
+++ b/setup.rb
@@ -9,13 +9,17 @@ ActiveRecord::Base.logger = Logger.new(STDOUT)
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'tmp/db')
 
 ActiveRecord::Schema.define do
-  drop_table :users
+  begin
+    drop_table :users
+    drop_table :comments
+  rescue
+    # tables will not exist on first run.
+  end
   create_table :users do |t|
     t.string :name
     t.string :email
   end
 
-  drop_table :comments
   create_table :comments do |t|
     t.integer :post_id
   end


### PR DESCRIPTION
I’ve added the iodine server for Ruby MRI.

I’ve also removed the reference to Sinatra beta, since version 2 was
released.

I updated `run.sh` to remove the benchmark result folders when starting
a new benchmark.

This will both prevent contamination (just in case) and automate the
folder tree to match any updates in the server list.

In `setup.rb` I’ve moved things around just to make sure that an
exception isn’t thrown on `drop_table`. The script seemed to assume a
prior database existed and this change simply protects against cases in
which this assumption might be incorrect.

It was a joy to run the benchmarks on my machine.

At the moment I fear the use of the server’s default concurrency model
might give some servers (i.g,`iodine` and `puma`) an unfair advantage
related to core-matching defaults… but I couldn’t find anything to do
about this.

Thanks!